### PR TITLE
update Alpine 3.6 to 3.8 to get a wget that works on Docker Hub builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN apk update \
  && apk add --no-cache rsyslog rsyslog-tls \


### PR DESCRIPTION
The automated postgresql-backup-restore image build on Docker Hub was failing on a wget.  Looks like the wget in BusyBox is broken in Alpine 3.6.  The workaround was to install the real wget with an "apk add --update ... wget".  The Docker build on Docker Hub worked when I updated to Alpine 3.8.  Since I based postgresql-backup-restore on mysql-backup-restore, the Alpine version update will be needed here eventually.

https://github.com/apache/incubator-openwhisk/pull/3715
https://github.com/coreos/awscli/pull/20