### PR TITLE
Upgrade Dockerfile to use Python3 docker hub image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.11
+FROM python:3-alpine
 
 RUN apk update \
  && apk add --no-cache \
             bash \
             mysql-client \
-            python py-pip \
+ && python -m pip install --upgrade pip \
  && pip install s3cmd python-magic
 
 COPY application/ /data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM python:3-alpine
 
+# Current version of s3cmd is in edge/testing repo
+RUN echo https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
+
+# Install everything via repo, because repo & pip installs can break things
 RUN apk update \
  && apk add --no-cache \
             bash \
             mysql-client \
- && python -m pip install --upgrade pip \
- && pip install s3cmd python-magic
+            py3-magic \
+            py3-dateutil \
+            py3-six \
+            s3cmd
 
 COPY application/ /data/
 WORKDIR /data


### PR DESCRIPTION
Python 2.x is deprecated, and so things should be Python 3 long term.