### PR TITLE
Don't create an unused directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ This image is built automatically on Docker Hub as [silintl/mysql-backup-restore
 You'll need [Docker](https://www.docker.com/get-docker), [Docker Compose](https://docs.docker.com/compose/install/), and [Make](https://www.gnu.org/software/make/).
 
 1. cd .../mysql-backup-restore
-2. mkdir ./mybackups
 3. Upload test/world.sql.gz to the S3 bucket.
 4. `make db`  # creates the MySQL DB server
 5. `make restore`  # restores the DB dump file


### PR DESCRIPTION
The example sequence doesn't need to create the mybackups/ directory.
It isn't used.