### PR TITLE
correct syntax for endpoint URL in S3 upload command

### DIFF
--- a/application/backup.sh
+++ b/application/backup.sh
@@ -215,7 +215,7 @@ for dbName in ${DB_NAMES}; do
         AWS_ACCESS_KEY_ID="${B2_APPLICATION_KEY_ID}" \
         AWS_SECRET_ACCESS_KEY="${B2_APPLICATION_KEY}" \
         aws s3 cp --quiet "/tmp/${dbName}.sql.gz" "${B2_BUCKET}/${dbName}.sql.gz" \
-          --endpoint-url = "https://${B2_HOST}"
+          --endpoint-url "https://${B2_HOST}"
         STATUS=$?
         end=$(date +%s)
         if [ $STATUS -ne 0 ]; then


### PR DESCRIPTION
### Changed 

- Remove stray space before = in the aws s3 cp call that caused the CLI to treat = as the endpoint URL value, resulting in exit code 255.