### PR TITLE
Fix Backblaze B2 upload failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Service to backup and/or restore mysql databases to/from S3 and optionally to B2
 
 `AWS_SECRET_KEY` used for S3 interactions (Deprecated)
 
-`B2_BUCKET` (optional) Name of the Backblaze B2 bucket, e.g., _database-backups_. When `B2_BUCKET` is defined, the backup file is copied to the B2 bucket in addition to the S3 bucket.
+`B2_BUCKET` (optional) Name of the Backblaze B2 bucket, e.g., _database-backups_ (bare name, no `s3://` prefix). When `B2_BUCKET` is defined, the backup file is copied to the B2 bucket in addition to the S3 bucket.
 
 >**It's recommended that your B2 bucket have versioning and encryption turned on.** Each backup creates a file of the form _dbname_.sql.gz. If versioning is not turned on, the previous backup file will be replaced with the new one, resulting in a single level of backups. Encryption may offer an additional level of protection from attackers. It also has the side effect of preventing downloads of the file via the Backblaze GUI (you'll have to use the `b2` command or the Backblaze API).
 

--- a/application/backup.sh
+++ b/application/backup.sh
@@ -214,7 +214,7 @@ for dbName in ${DB_NAMES}; do
         start=$(date +%s)
         AWS_ACCESS_KEY_ID="${B2_APPLICATION_KEY_ID}" \
         AWS_SECRET_ACCESS_KEY="${B2_APPLICATION_KEY}" \
-        aws s3 cp --quiet "/tmp/${dbName}.sql.gz" "${B2_BUCKET}/${dbName}.sql.gz" \
+        aws s3 cp --quiet "/tmp/${dbName}.sql.gz" "s3://${B2_BUCKET}/${dbName}.sql.gz" \
           --endpoint-url "https://${B2_HOST}"
         STATUS=$?
         end=$(date +%s)

--- a/compose.yaml
+++ b/compose.yaml
@@ -43,6 +43,9 @@ services:
             S3_BUCKET: s3://world
             DB_NAMES: world
             MODE: restore
+            AWS_ACCESS_KEY_ID: abc123
+            AWS_SECRET_ACCESS_KEY: abcd1234
+            AWS_ENDPOINT_URL: http://minio:9000
         depends_on:
             db:
                 condition: service_healthy


### PR DESCRIPTION
### Changed 

#### B2 upload block of application/backup.sh caused all Backblaze copies to fail with exit code 255:

- "${B2_BUCKET}/..." — the bucket name was passed without the required s3:// scheme, producing "Invalid argument type"
<img width="1520" height="155" alt="image" src="https://github.com/user-attachments/assets/953e063b-789c-45ea-8564-68bf57cf7689" />
