### PR TITLE
Replace phpMyAdmin with Adminer in Docker Compose setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 test: restore backup
 
+db:
+	docker compose up -d db adminer
+
 restore: bucket
 	docker compose run --rm app bash -c "aws s3 cp /root/world* \$$S3_BUCKET"
 	docker compose run --rm --env MODE=restore app

--- a/README.md
+++ b/README.md
@@ -52,19 +52,21 @@ This image is built automatically to GitHub Packages (GHCR)
 You'll need [Docker Engine](https://docs.docker.com/engine/) with the Docker Compose plugin and [Make](https://www.gnu.org/software/make/).
 
 1. cd .../mysql-backup-restore
+2. `cp local.env.dist local.env`
 3. Upload test/world.sql.gz to the S3 bucket.
-4. `make db`  # creates the MySQL DB server
-5. `make restore`  # restores the DB dump file
-6. `docker ps -a`  # get the Container ID of the exited restore container
-7. `docker logs <containerID>`  # review the restoration log messages
-8. `make backup`  # create a new DB dump file
-9. `docker ps -a`  # get the Container ID of the exited backup container
-10. `docker logs <containerID>`  # review the backup log messages
-11. `make restore`  # restore the DB dump file from the new backup
-12. `docker ps -a`  # get the Container ID of the exited restore container
-13. `docker logs <containerID>`  # review the restoration log messages
-14. `make clean`  # remove containers and network
-15. `docker volume ls`  # find the volume ID of the MySQL data container
-16. `docker volume rm <volumeID>`  # remove the data volume
-17. `docker images`  # list existing images
-18. `docker image rm <imageID ...>`  # remove images no longer needed
+4. `make db`  # starts the MariaDB server and Adminer
+5. Open http://localhost:8001 and log in to Adminer (System: MySQL, Server: `db`, Username: `root`, Password: `r00tp@ss!`)
+6. `make restore`  # restores the DB dump file
+7. `docker ps -a`  # get the Container ID of the exited restore container
+8. `docker logs <containerID>`  # review the restoration log messages
+9. `make backup`  # create a new DB dump file
+10. `docker ps -a`  # get the Container ID of the exited backup container
+11. `docker logs <containerID>`  # review the backup log messages
+12. `make restore`  # restore the DB dump file from the new backup
+13. `docker ps -a`  # get the Container ID of the exited restore container
+14. `docker logs <containerID>`  # review the restoration log messages
+15. `make clean`  # remove containers and network
+16. `docker volume ls`  # find the volume ID of the MySQL data container
+17. `docker volume rm <volumeID>`  # remove the data volume
+18. `docker images`  # list existing images
+19. `docker image rm <imageID ...>`  # remove images no longer needed

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,14 +17,12 @@ services:
             timeout: 5s
             retries: 3
 
-    phpmyadmin:
-        image: phpmyadmin/phpmyadmin:latest
+    adminer:
+        image: adminer:latest
         ports:
-            - "8001:80"
+            - "8001:8080"
         environment:
-            PMA_HOST: db
-            PMA_USER: root
-            PMA_PASSWORD: r00tp@ss!
+            ADMINER_DEFAULT_SERVER: db
 
     app:
         build: ./


### PR DESCRIPTION
### Changed

[ITSE-2817](https://support.gtis.sil.org/issue/ITSE-2817) Switch mysql-backup-restore over to use Adminer

* Replaced the `phpmyadmin` service with `adminer` in `compose.yaml`, updating the image, port mapping, and environment variables to use Adminer as the database UI.
* Updated the `Makefile` to add a new `db` target that starts both the MariaDB server and Adminer for easier local development.
* Revised the setup instructions in `README.md` to guide users through copying the environment file, starting the database and Adminer, and logging into Adminer with the correct credentials. The step numbers were adjusted to accommodate the new workflow.
